### PR TITLE
fix: missing include

### DIFF
--- a/src/args.cc
+++ b/src/args.cc
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <cstdint>
 
 namespace fasttext {
 


### PR DESCRIPTION
# Issue

Failed to install `fasttext` because C++ compiler complained of a missing `#include` of the standard library for type `uint64_t` in file `src/args.cc`.
